### PR TITLE
商品出品機能　再提出

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,13 +11,19 @@ class Item < ApplicationRecord
 
   VALID_PRICE_REGEX = /\A[-]?[0-9]+(\.[0-9]+)?\z/.freeze
 
-  validates :name, presence: true
-  validates :comment, presence: true
-  validates :price, presence: true, numericality: { less_than_or_equal_to: 9_999_999, greater_than_or_equal_to: 300 }, format: { with: VALID_PRICE_REGEX }
-  validates :category_id, numericality: { other_than: 1, message: "can't be blank"  }
-  validates :status_id, numericality: { other_than: 1, message: "can't be blank"  }
-  validates :delivery_id, numericality: { other_than: 1, message: "can't be blank"  }
-  validates :area_id, numericality: { other_than: 1, message: "can't be blank"  }
-  validates :day_id, numericality: { other_than: 1, message: "can't be blank"  }
-  validates :image, presence: true
+  with_options numericality: { other_than: 1, message: "can't be blank"  } do
+    validates :category_id
+    validates :status_id
+    validates :delivery_id
+    validates :area_id
+    validates :day_id
+  end
+
+  with_options presence: true do
+    validates :name
+    validates :comment
+    validates :price, numericality: { less_than_or_equal_to: 9_999_999, greater_than_or_equal_to: 300 }, format: { with: VALID_PRICE_REGEX }
+    validates :image
+  end
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,10 +14,10 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :comment, presence: true
   validates :price, presence: true, numericality: { less_than_or_equal_to: 9_999_999, greater_than_or_equal_to: 300 }, format: { with: VALID_PRICE_REGEX }
-  validates :category_id, presence: true
-  validates :status_id, presence: true
-  validates :delivery_id, presence: true
-  validates :area_id, presence: true
-  validates :day_id, presence: true
+  validates :category_id, numericality: { other_than: 1, message: "can't be blank"  }
+  validates :status_id, numericality: { other_than: 1, message: "can't be blank"  }
+  validates :delivery_id, numericality: { other_than: 1, message: "can't be blank"  }
+  validates :area_id, numericality: { other_than: 1, message: "can't be blank"  }
+  validates :day_id, numericality: { other_than: 1, message: "can't be blank"  }
   validates :image, presence: true
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -10,8 +10,5 @@ FactoryBot.define do
     day_id      {2}
     user_id     {2}
     association :user
-
-    # rspecでuserとのアソシエーションを組みましょう
-    # 検索がうまくヒットしない場合はfactorybot アソシエーションで調べましょう！
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -30,29 +30,34 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include("Comment can't be blank")
       end
       it 'カテゴリー選択がないと保存できない' do
-        @item.category_id = ''
+        @item.category_id = "1"
         @item.valid?
         expect(@item.errors.full_messages).to include("Category can't be blank")
       end
       it '商品状態の選択がないと保存できない' do
-        @item.status_id = ''
+        @item.status_id = "1"
         @item.valid?
         expect(@item.errors.full_messages).to include("Status can't be blank")
       end
       it '配送料の負担の選択がないと保存できない' do
-        @item.delivery_id = ''
+        @item.delivery_id = "1"
         @item.valid?
         expect(@item.errors.full_messages).to include("Delivery can't be blank")
       end
       it '発送元地域の選択がないと保存できない' do
-        @item.area_id = ''
+        @item.area_id = "1"
         @item.valid?
         expect(@item.errors.full_messages).to include("Area can't be blank")
       end
-      it '金額の入力がないと保存できない' do
-        @item.day_id = ''
+      it '発送日の選択がないと保存できない' do
+        @item.day_id = "1"
         @item.valid?
         expect(@item.errors.full_messages).to include("Day can't be blank")
+      end
+      it '金額の入力がないと保存できない' do
+        @item.price = ''
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it '価格の範囲が¥300以上でないと保存できない' do
         @item.price = 200


### PR DESCRIPTION
#what
商品出品機能のテストコード、バリデーションの再設定

#why
LGTMでしたがこちら、カテゴリー番号１を選んでもバリデーションがかかっていないため other_than: 0を追記し、テストコードも変更を加えております。